### PR TITLE
Fix bin generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [lib]
 crate-type = ["staticlib"] #Absolutely critical, haha.
-path = "src/main.rs"
+path = "src/lib.rs"
 
 [profile.dev]
 panic = "abort"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 //! minimal rust kernel built for (qemu virt machine) riscv.
 #![no_std]
 #![no_main]
+#![feature(pointer_byte_offsets)]
+
 
 use core::panic::PanicInfo;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 //! minimal rust kernel built for (qemu virt machine) riscv.
 #![no_std]
 #![no_main]
-#![feature(pointer_byte_offsets)]
-
 
 use core::panic::PanicInfo;
 


### PR DESCRIPTION
We don't need to make a binary file, and we can avoid it by renaming main.rs -> lib.rs and changing our Cargo.toml. Also building binary causes rustc to attept to link, and thus causes errors when you are relying on symbols provided by kernel.ld.