### PR TITLE
Add flake.nix, tweak build process a bit

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,6 @@
 [unstable]
-build-std-features = ["compiler-builtins-mem"]
 build-std = ["core", "compiler_builtins", "alloc"]
-
+build-std-features = ["compiler-builtins-mem"]
 
 [build]
-target = "riscv64gc-unknown-none-elf"
+target = "riscv64imac-unknown-none-elf"

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
-/target
+# Build artifacts
+/target/
 *~
 *.o
-*.ELF
+*.elf
 .rust*
 
-#exclude stuff from making presentation
+# IDE/direnv stuff
+.vscode/
+.idea/
+.direnv/
+
+# Presentation stuff
 /docs/presentation/*
 !/docs/presentation/slides.tex

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 
 [lib]
-crate-type = ["staticlib"] #Absolutely critical, haha.
+crate-type = ["staticlib"] # Absolutely critical, haha.
 path = "src/lib.rs"
 
 [profile.dev]

--- a/Makefile
+++ b/Makefile
@@ -1,68 +1,52 @@
-# args and whatnot
-LIBREEDOS=target/riscv64gc-unknown-none-elf/debug/libreedos.a
+RISCV64_AS ?= riscv64-none-elf-gcc-as
+RISCV64_LD ?= riscv64-none-elf-gcc-ld
+QEMU_FLAGS ?= -machine virt -smp 2 -m 128M -bios none -nographic
 
-ASM-GCC=riscv64-unknown-elf-gcc
-ASM-CFLAGS=
+LIBREEDOS := target/riscv64imac-unknown-none-elf/debug/libreedos.a
+ASM_FILES := $(shell find src -name *.s)
+OBJ_FILES := $(ASM_FILES:.s=.o) $(LIBREEDOS)
 
-LINKER=riscv64-unknown-elf-ld
-# first target is default
+################################################################
+
 ifeq ($(DEBUG),1)
-run: gdb-start
+default: qemu-gdb
 else
-run: start
+default: qemu
 endif
 
+################################################################
 
-# make global rule for all asm files
 %.o: %.s
-	$(ASM-GCC) -c $^ -o $@
+	$(RISCV64_AS) -c $^ -o $@ -march=rv64imac_zicsr_zifencei
 
-src/asm/entry.o: src/asm/entry.s
-src/asm/trap.o: src/asm/trap.s
-
-$(LIBREEDOS): .FORCE
+$(LIBREEDOS): .ALWAYS
 	cargo build
 
-# can't use automatic variables for dependencies, because we don't
-# want to mix kernel.ld with the rest
-# For reasons I don't understand, this order works and many others don't
-build: kernel.ld $(LIBREEDOS) src/asm/entry.o src/asm/trap.o .FORCE
-	$(LINKER) -Tkernel.ld -o reedos.ELF \
-		src/asm/entry.o src/asm/trap.o $(LIBREEDOS)
+reedos.elf: kernel.ld $(OBJ_FILES)
+	$(RISCV64_LD) -T$< -o $@ $(filter-out $<,$^)
 
-# other nice stuff
-lint:
-	#rustup component add rustfmt # Not for nightly
-	cargo fmt --all -- --check #Add config
+################################################################
+
+qemu-gdb: reedos.elf
+	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
+	qemu-system-riscv64 -s -S $(QEMU_FLAGS) -kernel $<
+
+qemu: reedos.elf
+	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
+	qemu-system-riscv64 $(QEMU_FLAGS) -kernel $<
+
+################################################################
+
+lint: .ALWAYS
+	cargo fmt --all -- --check
 	cargo clippy
 
-docs:
+docs: .ALWAYS
 	cargo doc --open
 
-gdb-start: build
-	echo "Ctrl-a x to quit qemu"
-	qemu-system-riscv64 -s -S \
-		-machine virt \
-		-smp 2 \
-		-m 128M \
-		-bios none \
-		-nographic \
-		-kernel reedos.ELF
-
-start: build
-	echo "Ctrl-a x to quit qemu"
-	qemu-system-riscv64 \
-		-machine virt \
-		-smp 2 \
-		-m 128M \
-		-bios none \
-		-nographic \
-		-kernel reedos.ELF
-
-clean:
+clean: .ALWAYS
 	cargo clean
-	rm -rf src/*.o
 	rm -rf src/asm/*.o
-	rm -rf reedos.ELF
+	rm -rf reedos.elf
 
-.PHONY: .FORCE
+.PHONY: .ALWAYS

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1678901627,
+        "narHash": "sha256-U02riOqrKKzwjsxc/400XnElV+UtPUQWpANPlyazjH0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "93a2b84fc4b70d9e089d029deacc3583435c2ed6",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1679793451,
+        "narHash": "sha256-JafTtgMDATE8dZOImBhWMA9RCn9AP8FVOpN+9K/tTlg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cd51a933d91078775b300cf0f29aa3495231aa2",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679970108,
+        "narHash": "sha256-8OfySbY1hhBzj0Iz90k4se6oFCGS3+ke31vkd0d4k/o=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "26ef1a2029239e204e51ab3402f8aae5aa1187ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Tools needed to develop reedos";
+
+  inputs.rust-overlay = {
+    url = "github:oxalica/rust-overlay";
+    inputs.nixpkgs.follows = "nixpkgs";
+    inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+        riscv64-cc = pkgs.pkgsCross.riscv64-embedded.stdenv.cc;
+      in {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            (rust-bin.nightly.latest.default.override {
+              extensions = [ "rust-src" ];
+              targets = [ "riscv64imac-unknown-none-elf" ];
+            })
+            riscv64-cc
+          ];
+
+          RISCV64_AS = "${riscv64-cc}/bin/${riscv64-cc.targetPrefix}as";
+          RISCV64_LD = "${riscv64-cc}/bin/${riscv64-cc.targetPrefix}ld";
+        };
+      });
+}

--- a/src/vm/process.rs
+++ b/src/vm/process.rs
@@ -3,12 +3,12 @@
 
 // extern crate alloc;
 
-use alloc::boxed::Box;
-use alloc::collections::BTreeSet;
 use crate::hw::HartContext;
 use crate::trap::TrapFrame;
 use crate::vm::ptable::PageTable;
 use crate::vm::Resource;
+use alloc::boxed::Box;
+use alloc::collections::BTreeSet;
 
 pub struct Process {
     id: usize,


### PR DESCRIPTION
This adds a `flake.nix` containing everything(?) needed to build reedos (can be used with direnv!), as well as making some subjective tweaks to the Makefile. The target has also been changed to `riscv64imac` instead of `riscv64gc`, since reedos currently only seems to need `rv64imac_zicsr_zifencei`, and Rust has no built-in `riscv32gc` target AFAICT :(.

The biggest developer-facing change here is that the `start` and `gdb-start` Makefile targets have been renamed to `qemu` and `qemu-gdb`. Feedback is welcome :).