### PR TITLE
Use cargo for building and running

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ build-std-features = ["compiler-builtins-mem"]
 [build]
 target = "riscv64imac-unknown-none-elf"
 rustflags = ["-C", "link-args=-Tkernel.ld"]
+
+[target.riscv64imac-unknown-none-elf]
+runner = "./qemu-wrapper.sh riscv64"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,3 +4,4 @@ build-std-features = ["compiler-builtins-mem"]
 
 [build]
 target = "riscv64imac-unknown-none-elf"
+rustflags = ["-C", "link-args=-Tkernel.ld"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,6 @@ edition = "2021"
 
 [dependencies]
 
-[lib]
-crate-type = ["staticlib"] # Absolutely critical, haha.
-path = "src/lib.rs"
-
 [profile.dev]
 panic = "abort"
 

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ RISCV64_AS ?= riscv64-none-elf-gcc-as
 RISCV64_LD ?= riscv64-none-elf-gcc-ld
 QEMU_FLAGS ?= -machine virt -smp 2 -m 128M -bios none -nographic
 
-LIBREEDOS := target/riscv64imac-unknown-none-elf/debug/libreedos.a
-ASM_FILES := $(shell find src -name *.s)
-OBJ_FILES := $(ASM_FILES:.s=.o) $(LIBREEDOS)
+REEDOS := target/riscv64imac-unknown-none-elf/debug/reedos
 
 ################################################################
 
@@ -16,22 +14,14 @@ endif
 
 ################################################################
 
-%.o: %.s
-	$(RISCV64_AS) -c $^ -o $@ -march=rv64imac_zicsr_zifencei
-
-$(LIBREEDOS): .ALWAYS
+$(REEDOS): .ALWAYS
 	cargo build
 
-reedos.elf: kernel.ld $(OBJ_FILES)
-	$(RISCV64_LD) -T$< -o $@ $(filter-out $<,$^)
-
-################################################################
-
-qemu-gdb: reedos.elf
+qemu-gdb: $(REEDOS)
 	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
 	qemu-system-riscv64 -s -S $(QEMU_FLAGS) -kernel $<
 
-qemu: reedos.elf
+qemu: $(REEDOS)
 	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
 	qemu-system-riscv64 $(QEMU_FLAGS) -kernel $<
 
@@ -46,7 +36,5 @@ docs: .ALWAYS
 
 clean: .ALWAYS
 	cargo clean
-	rm -rf src/asm/*.o
-	rm -rf reedos.elf
 
 .PHONY: .ALWAYS

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,13 @@
-RISCV64_AS ?= riscv64-none-elf-gcc-as
-RISCV64_LD ?= riscv64-none-elf-gcc-ld
-QEMU_FLAGS ?= -machine virt -smp 2 -m 128M -bios none -nographic
-
-REEDOS := target/riscv64imac-unknown-none-elf/debug/reedos
-
-################################################################
-
-ifeq ($(DEBUG),1)
-default: qemu-gdb
-else
 default: qemu
-endif
 
-################################################################
-
-$(REEDOS): .ALWAYS
+build: .ALWAYS
 	cargo build
 
+qemu: .ALWAYS
+	cargo run
+
 qemu-gdb: $(REEDOS)
-	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
-	qemu-system-riscv64 -s -S $(QEMU_FLAGS) -kernel $<
-
-qemu: $(REEDOS)
-	$(info $(shell tput setaf 5)Use CTRL-A, X to quit QEMU.$(shell tput sgr0))
-	qemu-system-riscv64 $(QEMU_FLAGS) -kernel $<
-
-################################################################
+	DEBUG=1 cargo run
 
 lint: .ALWAYS
 	cargo fmt --all -- --check
@@ -37,4 +19,4 @@ docs: .ALWAYS
 clean: .ALWAYS
 	cargo clean
 
-.PHONY: .ALWAYS
+.PHONY: default .ALWAYS

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: .ALWAYS
 qemu: .ALWAYS
 	cargo run
 
-qemu-gdb: $(REEDOS)
+qemu-gdb:
 	DEBUG=1 cargo run
 
 lint: .ALWAYS

--- a/README.md
+++ b/README.md
@@ -1,59 +1,88 @@
 # reedos
-You could say reed-oh-ESS, but we like to think it's barely FreeDOS minus the 'f'. Like rEE-doss.
 
-See [Contribution Guidelines](CONTRIBUTING.md) if you're interested in getting involved.
+You could say reed-oh-ESS, but we like to think it's barely FreeDOS minus the
+'f'. Like rEE-doss.
+
+See [Contribution Guidelines](CONTRIBUTING.md) if you're interested in getting
+involved.
 
 ### Notes
-We currently support Rust's `GlobalAlloc` in order to use the `alloc` crate. We do so by wrapping page 
-allocation and finer grained virtual memory allocation into a `Global Allocator` struct which implements
-Rust's `GlobalAlloc` trait. As an example, this is valid `reedos` kernel code:
-```
+
+We currently support Rust's `GlobalAlloc` in order to use the `alloc` crate. We
+do so by wrapping page allocation and finer grained virtual memory allocation
+into a `Global Allocator` struct which implements Rust's `GlobalAlloc` trait. As
+an example, this is valid `reedos` kernel code:
+
+```rust
 use alloc::collections;
-    {
-        // Simple test. It works!
-        let mut one = Box::new(5);
+{
+    // Simple test. It works!
+    let mut one = Box::new(5);
 
-        // Slightly more interesting... it also works! Look at this with GDB
-        // and watch for the zone headers + chunk headers indicating 'in use' and
-        // 'chunk size'. Then watch the headers as these go out of scope.
-        let mut one_vec: Box<collections::VecDeque<u32>> = Box::default();
-        one_vec.push_back(555);
-        one_vec.push_front(111);
-    }
+    // Slightly more interesting... it also works! Look at this with GDB
+    // and watch for the zone headers + chunk headers indicating 'in use' and
+    // 'chunk size'. Then watch the headers as these go out of scope.
+    let mut one_vec: Box<collections::VecDeque<u32>> = Box::default();
+    one_vec.push_back(555);
+    one_vec.push_front(111);
+}
 
-    {
-        // Now, more than a page.
-        let mut big: Box<[u64; 513]> = Box::new([0x8BADF00D; 513]);
-    }
-
+{
+    // Now, more than a page.
+    let mut big: Box<[u64; 513]> = Box::new([0x8BADF00D; 513]);
+}
 ```
 
 ## Setup
+
 In order to get started with this project you'll need the following:
-- Rust (currently on nightly branch) 
+
+- Rust (currently on nightly branch)
 - QEMU compiled for riscv
 - `riscv-gnu-toolchain` (don't forget to add to PATH)
 - `rustup target add riscv64gc-unkown-none-elf`
+
+If you have [Nix](https://nixos.org/download.html) installed, you should be able
+to get all of these by running `nix develop` (can be automatically loaded when
+you enter the directory if you have direnv).
+
 ## Usage
-- Build, link, and run reedos on Qemu virt machine:
-`$ make run`
- - Qemu `-nographic` is exited with `C-a x`, that is `Control + a` followed by `x`.
-   -  with `c` instead gives a console, but you will find `gdb` to much more helpful.
- - Clean up build artifacts:
-`$ make clean`
+
+Pretty much everything can be done through cargo now:
+| Cargo | Make | Description |
+|-------|------|-------------|
+| `cargo build` | `make build` | build (output is `target/<ARCH>/<PROFILE>/reedos`) |
+| `cargo run` | `make qemu` | build and run with QEMU |
+| `DEBUG=1 cargo run` | `make qemu-gdb` | build and run with QEMU (wait for gdb) |
+| `cargo doc --open` | `make docs` | build and open documentation in a browser |
+| `cargo clean` | `make clean` | remove `target/` directory |
+
+You can exit QEMU by pressing <kbd>Ctrl</kbd> + <kbd>a</kbd>, then <kbd>x</kbd>.
+
+- <kbd>Ctrl</kbd> + <kbd>a</kbd>, <kbd>c</kbd> gives a console, but you will
+  find `gdb` much more helpful.
 
 ### Debug tools
+
 You may find the following debug tools (that you have mostly already installed) helpful:
-- `riscv64-unknown-elf-{objdump, gdb}` <-- Recommend viewing docs material on becoming a GDB power user.
-- In Qemu with `-nographic` use `Ctr+A` then `c` to get to console, run `help` to see available commands.
+
+- `riscv64-unknown-elf-{objdump, gdb}` ← Recommend viewing docs material on
+  becoming a GDB power user.
+- In QEMU with `-nographic`, use <kbd>Ctrl</kbd> + <kbd>a</kbd>, then
+  <kbd>c</kbd> to get to the console, then run `help` to see available commands.
 
 ### Docs
- + `$ make docs` builds and open documentation in browser (equal to `cargo docs --open`, can't ever remember this command).
- 
+
+- Use `make docs` or `cargo doc --open` to build and open the crate
+  documentation in a browser.
+- Make sure to read the documentation in `docs/` too!
+
 ### References
-+ [ISA Manual](https://riscv.org/technical/specifications/) (Go to "Volume 2, Privileged Specification")
-+ [Nomicon](https://doc.rust-lang.org/nomicon/)
-+ [Interrupt Cookbook](https://www.starfivetech.com/uploads/sifive-interrupt-cookbook-v1p2.pdf)
-+ [MIT's XV6-RISCV](https://github.com/mit-pdos/xv6-riscv)
-+ [Marz's OSDEV Blog OS](https://osblog.stephenmarz.com/index.html)
-+ [Phil-Opp's Blog OS](https://os.phil-opp.com/)
+
+- [ISA Manual](https://riscv.org/technical/specifications/) (Go to "Volume 2, Privileged Specification")
+- [Rustonomicon](https://doc.rust-lang.org/nomicon/)
+- [Embedonomicon](https://docs.rust-embedded.org/embedonomicon/index.html)
+- [Interrupt Cookbook](https://www.starfivetech.com/uploads/sifive-interrupt-cookbook-v1p2.pdf)
+- [MIT's XV6-RISCV](https://github.com/mit-pdos/xv6-riscv)
+- [Marz's OSDEV Blog OS](https://osblog.stephenmarz.com/index.html)
+- [Phil-Opp's Blog OS](https://os.phil-opp.com/)

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,7 @@
               targets = [ "riscv64imac-unknown-none-elf" ];
             })
             riscv64-cc
+            qemu
           ];
 
           RISCV64_AS = "${riscv64-cc}/bin/${riscv64-cc.targetPrefix}as";

--- a/kernel.ld
+++ b/kernel.ld
@@ -3,57 +3,61 @@ ENTRY( _entry )
 
 MEMORY
 {
-  ram  (wxa) : ORIGIN = 0x80000000, LENGTH = 128M
+  RAM  (wxa) : ORIGIN = 0x80000000, LENGTH = 128M
 }
 
 SECTIONS
 {
+  . = ORIGIN(RAM);
+
   .text : {
-      *(.text .text.*)
-      . = ALIGN(0x1000);
-      PROVIDE(_text_end = .);
-      PROVIDE(_etext = .);
+    *(.text.entry)
+    *(.text .text.*)
+    . = ALIGN(0x1000);
+    PROVIDE(_text_end = .);
+    PROVIDE(_etext = .);
   }
 
   PROVIDE(_global_pointer = .);
 
   .rodata : {
-      *(.srodata .srodata.*)
-      *(.rodata .rodata.*)
-      . = ALIGN(0x1000);
-      PROVIDE(_roedata = .);
+    *(.srodata .srodata.*)
+    *(.rodata .rodata.*)
+    . = ALIGN(0x1000);
+    PROVIDE(_roedata = .);
   }
   .data : {
-      *(.sdata .sdata.*)
-      *(.data .data.*)
-      . = ALIGN(0x1000);
-      PROVIDE(_edata = .);
+    *(.sdata .sdata.*)
+    *(.data .data.*)
+    . = ALIGN(0x1000);
+    PROVIDE(_edata = .);
   }
 
   /* lower guard page included in above */
   .stacks : {
-      . = ALIGN(0x1000);
-      PROVIDE(_stacks_start = .);
-      . = . + (4096 * 3 * 2); /* NHARTS with a guard page each, unstable */
-      PROVIDE(_stacks_end = .);
+    . = ALIGN(0x1000);
+    PROVIDE(_stacks_start = .);
+    . = . + (4096 * 3 * 2); /* NHARTS with a guard page each, unstable */
+    PROVIDE(_stacks_end = .);
   }
   .intstacks : {
-      . = ALIGN(0x1000);
-      PROVIDE(_intstacks_start = .);
-      . = . + (0x1000 * 4 * 2);
-      PROVIDE(_intstacks_end = .);
+    . = ALIGN(0x1000);
+    PROVIDE(_intstacks_start = .);
+    . = . + (0x1000 * 4 * 2);
+    PROVIDE(_intstacks_end = .);
   }
   . = . + 4096; /* guard page */
   /* stacks should start at stack end and alternate with guard pages going down */
 
   .bss : {
-      . = ALIGN(0x1000);
-      PROVIDE(_bss_start = .);
-      *(.sbss .sbss.*)
-      *(.bss .bss.*)
-      . = ALIGN(0x1000);
-      PROVIDE(_bss_end = .);
+    . = ALIGN(0x1000);
+    PROVIDE(_bss_start = .);
+    *(.sbss .sbss.*)
+    *(.bss .bss.*)
+    . = ALIGN(0x1000);
+    PROVIDE(_bss_end = .);
   }
+
   PROVIDE(_end = .);
-  PROVIDE(_memory_end = ORIGIN(ram) + LENGTH(ram));
+  PROVIDE(_memory_end = ORIGIN(RAM) + LENGTH(RAM));
 }

--- a/qemu-wrapper.sh
+++ b/qemu-wrapper.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+##
+## This is just a wrapper for QEMU that adds the -s -S (for gdb) flags when
+## DEBUG is set, to be used as a binary runner by Cargo.
+##
+
+set -euo pipefail
+
+FLAGS=(-machine virt -smp 2 -m 128M -bios none -nographic)
+
+print_help() { echo "$(tput setaf 2)$(tput bold)(info)$(tput sgr0) $1"; }
+
+print_help "Type CTRL-A, X to exit QEMU"
+if [[ -v DEBUG ]]; then
+    FLAGS+=(-s -S)
+    print_help "Starting QEMU in debug mode (connect with gdb)"
+fi
+set -x
+exec "qemu-system-$1" "${FLAGS[@]}" -kernel "$2"

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,0 +1,4 @@
+use core::arch::global_asm;
+
+global_asm!(include_str!("asm/entry.s"));
+global_asm!(include_str!("asm/trap.s"));

--- a/src/asm/entry.s
+++ b/src/asm/entry.s
@@ -1,55 +1,49 @@
 # Kernel entry point.
-# The linker script provides us with symbols which are necessary for
-# us to configure our kernel memory layout. Primarily, notice that
-# kernel code starts at address 0x80000000. Physical addresses below
-# this contain memory mapped IO devices (CLINT, PLIC, UART NS16550A,
-# ...).  This entry function is loaded at address 0x80000000 since
-# it is a .text section and the linker lays those out first. This
-# entry function's job is to set up the kernel stack so we have some
-# space to work. Refer to src/param.rs for general memory
-# layout. The kernel stack depends on the number of harts on the h/w
-# (or qemu).  We mostly reference this from
-# `xv6-riscv/kernel/entry.S`.
-
-# For some reason gcc wants hashes but other people (like emacs) want to use semicolons
+# The linker script provides us with symbols which are necessary for us to
+# configure our kernel memory layout. Primarily, notice that kernel code starts
+# at address 0x80000000. Physical addresses below this contain memory mapped IO
+# devices (CLINT, PLIC, UART NS16550A, ...).  This entry function is loaded at
+# address 0x80000000 since it is a .text section and the linker lays those out
+# first. This entry function's job is to set up the kernel stack so we have some
+# space to work. Refer to src/param.rs for general memory layout. The kernel
+# stack depends on the number of harts on the h/w (or qemu).  We mostly
+# reference this from `xv6-riscv/kernel/entry.S`.
 
     .option norvc
     .section .text.entry
-
     .global _entry
-    _entry:
-
+_entry:
     .option push
     .option norelax
-        # Linker position data relative to gp
+    # Linker position data relative to gp
     .extern _global_pointer
-        la gp, _global_pointer
+    la gp, _global_pointer
     .option pop
-        # Set up stack per of hart ids according to linker script
+    # Set up stack per of hart ids according to linker script
 
-        # Add 4k guard page per hart
-        csrr a1, mhartid
-        #sll a1, a1, 1 # Multiple hartid by 2 to get alternating pages
-        li a0, 0x3000
-        mul a1, a1, a0
-    .extern _stacks_end # Linker supplied
-        la a2, _stacks_end
-        sub sp, a2, a1
+    # Add 4k guard page per hart
+    csrr a1, mhartid
+    #sll a1, a1, 1 # Multiple hartid by 2 to get alternating pages
+    li a0, 0x3000
+    mul a1, a1, a0
+    .extern _stacks_end
+    la a2, _stacks_end
+    sub sp, a2, a1
 
     .extern _intstacks_end
-        csrr a1, mhartid
-        li a0, 0x4000
-        mul a1, a1, a0
-        la a2, _intstacks_end
-        sub a2, a2, a1
-        csrw mscratch, a2 # Write per hart mscratch pad
-        li a0, 0x2000
-        sub a2, a2, a0 # Move sp down by scratch pad page + guard page
-        csrw sscratch, a2 # Write per hart sscratch pad
+    csrr a1, mhartid
+    li a0, 0x4000
+    mul a1, a1, a0
+    la a2, _intstacks_end
+    sub a2, a2, a1
+    csrw mscratch, a2 # Write per hart mscratch pad
+    li a0, 0x2000
+    sub a2, a2, a0 # Move sp down by scratch pad page + guard page
+    csrw sscratch, a2 # Write per hart sscratch pad
 
-        # Jump to _start in src/main.rs
+    # Jump to _start in src/main.rs
     .extern _start
-        call _start
-    spin:
-        wfi
-        j spin
+    call _start
+spin:
+    wfi
+    j spin

--- a/src/asm/entry.s
+++ b/src/asm/entry.s
@@ -14,7 +14,7 @@
 # For some reason gcc wants hashes but other people (like emacs) want to use semicolons
 
     .option norvc
-    .section .text
+    .section .text.entry
 
     .global _entry
     _entry:

--- a/src/asm/trap.s
+++ b/src/asm/trap.s
@@ -76,14 +76,14 @@
     .align 4
     .global __mtrapvec
 __mtrapvec:
-	csrrw sp, mscratch, sp
-	save_gp_regs    
+    csrrw sp, mscratch, sp
+    save_gp_regs
 
-	.extern m_handler
+    .extern m_handler
     call m_handler
-	
-	load_gp_regs
-	csrrw sp, mscratch, sp
+
+    load_gp_regs
+    csrrw sp, mscratch, sp
     mret
 
 # This is the supervisor trap vector, it just exists to get
@@ -92,12 +92,12 @@ __mtrapvec:
     .align 4
     .globl __strapvec
  __strapvec:
-	csrrw sp, sscratch, sp
-	save_gp_regs
+    csrrw sp, sscratch, sp
+    save_gp_regs
 
     .extern s_handler
     call s_handler
 
-	load_gp_regs
-	csrrw sp, sscratch, sp
+    load_gp_regs
+    csrrw sp, sscratch, sp
     sret

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate alloc;
 
 #[macro_use]
 pub mod log;
+pub mod asm;
 pub mod device;
 pub mod hw;
 pub mod lock;


### PR DESCRIPTION
Everything can be done through cargo now (although the Makefile still exists). This also:
- fixes some minor indentation annoyances in the assembly files
- updates the README to mention the new build process and flake
- adds QEMU to the flake devShell packages