### PR TITLE
Phys page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,7 @@ fn main() -> ! {
             log!(Debug, "Testing galloc allocation and freeing...");
             vm::test_galloc();
         }
+        log!(Info, "Completed all initialization and testing...");
     } else {
         //Interrupt other harts to init kpgtable.
         trap::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,10 @@ fn main() -> ! {
             log!(Debug, "Testing galloc allocation and freeing...");
             vm::test_galloc();
         }
-        log!(Info, "Completed all initialization and testing...");
+        log!(Debug, "Testing phys page extent allocation and freeing...");
+        vm::test_phys_page();
+        log!(Debug, "Successful phys page extent allocation and freeing...");
+        log!(Info, "Completed all hart0 initialization and testing...");
     } else {
         //Interrupt other harts to init kpgtable.
         trap::init();

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -9,7 +9,6 @@ use crate::hw::param::*;
 use alloc::boxed::Box;
 use core::alloc::{GlobalAlloc, Layout};
 use core::cell::OnceCell;
-use core::mem::size_of;
 
 use global::Galloc;
 use palloc::*;
@@ -214,8 +213,8 @@ pub fn request_phys_page(num: usize) -> Result<PhysPageExtent, VmError>{
 
 pub fn test_phys_page() {
     {
-        let ppe1 = request_phys_page(1).unwrap();
-        let ppe2 = request_phys_page(2).unwrap();
+        let _ = request_phys_page(1).unwrap();
+        let _ = request_phys_page(2).unwrap();
     }
-    let ppe11 = request_phys_page(1).unwrap();
+    let _ = request_phys_page(1).unwrap();
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -217,3 +217,11 @@ pub fn request_phys_page(num: usize) -> Result<PhysPageExtent, VmError>{
         num,
     })
 }
+
+pub fn test_phys_page() {
+    {
+        let ppe1 = request_phys_page(1).unwrap();
+        let ppe2 = request_phys_page(2).unwrap();
+    }
+    let ppe11 = request_phys_page(1).unwrap();
+}

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -182,7 +182,7 @@ impl PhysPageExtent {
 
     pub fn end(&self) -> *mut usize {
         unsafe {
-            self.head.addr.offset((self.num * PAGE_SIZE / (size_of::<usize>())) as isize)
+            self.head.addr.byte_add(self.num * PAGE_SIZE)
         }
     }
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -205,6 +205,8 @@ impl Drop for PhysPageExtent {
     }
 }
 
+unsafe impl Send for PhysPageExtent {}
+
 /// Should be one and only way to get physical pages outside of vm module/subsystem.
 pub fn request_phys_page(num: usize) -> Result<PhysPageExtent, VmError>{
     let addr = unsafe {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -140,12 +140,6 @@ pub unsafe fn test_galloc() {
         let _a_vec: *mut collections::VecDeque<u32> = one_vec.as_mut();
     }
 
-    {
-        // More than a page.
-        let mut big: Box<[u64; 513]> = Box::new([0x8BADF00D; 513]);
-        let _a_big = big.as_mut();
-    }
-
     log!(Debug, "Successful test of alloc crate...");
 }
 

--- a/src/vm/palloc.rs
+++ b/src/vm/palloc.rs
@@ -346,3 +346,4 @@ impl PagePool {
         PagePool { pool }
     }
 }
+


### PR DESCRIPTION
Want as a depedency of processes, so that we can avoid dropping phys pages when we kill a process uncleanly. Also preserves nice module containers when we move process out of vm.